### PR TITLE
docs(dashboard): add static metrics dashboard (Prometheus/JSON), samples, README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,29 @@ To understand how the source code is organized, you should start by reading
 the execution [developer overview](docs/overview.md), which explains how
 execution and consensus fit together, and where in the source tree you can
 find different pieces of functionality.
+
+## Metrics dashboard (docs)
+
+A lightweight static dashboard is available under `docs/` to visualize metrics from this app or any Prometheus/JSON endpoints.
+
+How to open locally:
+
+1. Serve the `docs/` directory to allow XHR to local files/URLs:
+
+   - Python: `python3 -m http.server -d docs 8080`
+   - Node: `npx http-server docs -p 8080 --no-cache`
+
+2. Open `http://localhost:8080/dashboard.html` in your browser.
+
+3. Add one or more sources:
+   - Paste a metrics URL (e.g., `http://localhost:9100/metrics`) and click “Add URL”.
+   - Or use the file picker to load local files (Prometheus text or JSON).
+
+4. Try the included samples in `docs/`:
+   - `metrics-sample.txt`
+   - `metrics-sample.json`
+
+Notes:
+- Prometheus text parsing supports `name{label="value"} number` lines; comments are ignored.
+- JSON parsing accepts arrays of `{ name, value, labels? }` or simple object maps.
+- Auto-refresh interval is configurable; use “Refresh Now” for manual fetch.

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Monad Metrics Dashboard</title>
+    <style>
+        :root { color-scheme: light dark; }
+        body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; margin: 16px; }
+        h1 { margin: 0 0 12px; font-size: 1.6rem; }
+        .toolbar { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: end; margin-bottom: 16px; }
+        .controls { display: grid; gap: 8px; }
+        .row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+        input[type="text"], input[type="number"] { padding: 8px; border-radius: 6px; border: 1px solid #8884; min-width: 240px; }
+        button { padding: 8px 12px; border-radius: 6px; border: 1px solid #8884; background: #eee; cursor: pointer; }
+        button:hover { filter: brightness(0.98); }
+        .sources { display: flex; flex-wrap: wrap; gap: 6px; }
+        .chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 999px; border: 1px solid #8884; font-size: 0.9rem; }
+        .chip button { border: none; background: none; cursor: pointer; padding: 0 4px; }
+        .status { font-size: 0.9rem; opacity: 0.8; }
+        .grid { overflow: auto; border: 1px solid #8884; border-radius: 8px; }
+        table { width: 100%; border-collapse: collapse; }
+        thead { position: sticky; top: 0; background: color-mix(in oklab, Canvas 92%, CanvasText 0%); }
+        th, td { padding: 8px 10px; border-bottom: 1px solid #8882; text-align: left; white-space: nowrap; }
+        tbody tr:hover { background: #8881; }
+        .muted { opacity: 0.7; }
+        .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+        .help { font-size: 0.9rem; margin: 8px 0 16px; }
+        .spacer { flex: 1 1 auto; }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+</head>
+<body>
+    <h1>Monad Metrics Dashboard</h1>
+    <div class="help">
+        Add one or more metric sources (URLs or local files). Supports basic Prometheus text format and simple JSON.
+        For local preview with URL sources, you may need a static server (example: <span class="mono">python3 -m http.server -d docs 8080</span>).
+    </div>
+
+    <div class="toolbar">
+        <div class="controls">
+            <div class="row">
+                <input id="urlInput" type="text" placeholder="Add metrics URL (e.g. http://localhost:9100/metrics)">
+                <button id="addSourceBtn">Add URL</button>
+                <input id="fileInput" type="file" multiple>
+                <label class="row">
+                    <span>Refresh (s)</span>
+                    <input id="refreshInterval" type="number" min="2" step="1" value="10" style="width: 80px;">
+                </label>
+                <label class="row"><input id="autoRefresh" type="checkbox" checked> <span>Auto refresh</span></label>
+                <button id="refreshNowBtn">Refresh Now</button>
+                <span class="spacer"></span>
+            </div>
+            <div class="row">
+                <input id="filterInput" type="text" placeholder="Filter metrics by name...">
+                <span class="status" id="status"></span>
+            </div>
+            <div class="row">
+                <span class="muted">Quick samples:</span>
+                <button id="loadSampleTxt">Load sample Prometheus</button>
+                <button id="loadSampleJson">Load sample JSON</button>
+                <a class="muted" href="metrics-sample.txt" target="_blank" rel="noopener">metrics-sample.txt</a>
+                <a class="muted" href="metrics-sample.json" target="_blank" rel="noopener">metrics-sample.json</a>
+            </div>
+            <div class="sources" id="sources"></div>
+        </div>
+    </div>
+
+    <div class="grid">
+        <table id="metricsTable">
+            <thead>
+                <tr id="tableHead">
+                    <th>Metric</th>
+                    <th>Aggregate</th>
+                    <th class="muted">Details</th>
+                </tr>
+            </thead>
+            <tbody id="tableBody"></tbody>
+        </table>
+    </div>
+
+    <script src="./dashboard.js"></script>
+</body>
+</html>
+

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,0 +1,261 @@
+(() => {
+    /** @typedef {{sourceId: string, kind: 'url'|'file', name: string}} Source */
+    /** @typedef {{name: string, value: number, labels?: Record<string,string>, source?: string}} Metric */
+
+    const state = {
+        /** @type {Map<string, Source>} */
+        sources: new Map(),
+        /** @type {Map<string, Metric[]>} */
+        metricsByName: new Map(),
+        filterText: '',
+        refreshTimer: /** @type {number|undefined} */ (undefined),
+    };
+
+    const dom = {
+        urlInput: /** @type {HTMLInputElement} */ (document.getElementById('urlInput')),
+        addSourceBtn: /** @type {HTMLButtonElement} */ (document.getElementById('addSourceBtn')),
+        fileInput: /** @type {HTMLInputElement} */ (document.getElementById('fileInput')),
+        refreshInterval: /** @type {HTMLInputElement} */ (document.getElementById('refreshInterval')),
+        autoRefresh: /** @type {HTMLInputElement} */ (document.getElementById('autoRefresh')),
+        refreshNowBtn: /** @type {HTMLButtonElement} */ (document.getElementById('refreshNowBtn')),
+        filterInput: /** @type {HTMLInputElement} */ (document.getElementById('filterInput')),
+        status: /** @type {HTMLElement} */ (document.getElementById('status')),
+        sources: /** @type {HTMLElement} */ (document.getElementById('sources')),
+        tableBody: /** @type {HTMLElement} */ (document.getElementById('tableBody')),
+        tableHead: /** @type {HTMLElement} */ (document.getElementById('tableHead')),
+    };
+
+    const uid = () => Math.random().toString(36).slice(2, 10);
+
+    function setStatus(text) {
+        dom.status.textContent = text;
+    }
+
+    function addSource(kind, name) {
+        const sourceId = uid();
+        state.sources.set(sourceId, { sourceId, kind, name });
+        drawSources();
+        return sourceId;
+    }
+
+    function removeSource(sourceId) {
+        state.sources.delete(sourceId);
+        drawSources();
+    }
+
+    function drawSources() {
+        dom.sources.innerHTML = '';
+        for (const [sourceId, s] of state.sources.entries()) {
+            const chip = document.createElement('span');
+            chip.className = 'chip';
+            chip.textContent = s.name;
+            const x = document.createElement('button');
+            x.textContent = '×';
+            x.title = 'Remove';
+            x.addEventListener('click', () => removeSource(sourceId));
+            chip.appendChild(x);
+            dom.sources.appendChild(chip);
+        }
+    }
+
+    async function fetchTextFromSource(source) {
+        if (source.kind === 'url') {
+            const res = await fetch(source.name, { cache: 'no-store' });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const ct = res.headers.get('content-type') || '';
+            if (ct.includes('application/json')) {
+                const json = await res.json();
+                return { type: 'json', text: JSON.stringify(json), json };
+            }
+            const text = await res.text();
+            return { type: 'text', text };
+        } else {
+            // 'file' kind stores a pseudo-URL name like file:<id>, but we keep File in closure
+            // Here, name is used only for labeling; actual content loaded on add
+            // This path is not called; file content is provided directly by caller
+            throw new Error('Unsupported direct file fetch');
+        }
+    }
+
+    function parsePrometheusText(content) {
+        /** @type {Metric[]} */
+        const out = [];
+        const lines = content.split(/\r?\n/);
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith('#')) continue;
+            // example: http_requests_total{method="post",code="200"} 1027
+            const match = trimmed.match(/^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)(?<labels>\{[^}]*\})?\s+(?<value>[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)\s*(?<ts>[0-9]+)?/);
+            if (!match || !match.groups) continue;
+            const name = match.groups.name;
+            const value = Number(match.groups.value);
+            /** @type {Record<string,string>|undefined} */
+            let labels;
+            if (match.groups.labels) {
+                labels = {};
+                const raw = match.groups.labels.slice(1, -1);
+                for (const kv of raw.split(/,(?=(?:[^\\"]*\\"[^\\"]*\\")*[^\\"]*$)/)) {
+                    const [k, v] = kv.split('=');
+                    if (!k) continue;
+                    const unq = (v || '').replace(/^\"|\"$/g, '').replace(/\\\"/g, '"');
+                    labels[k.trim()] = unq;
+                }
+            }
+            out.push({ name, value, labels });
+        }
+        return out;
+    }
+
+    function parseJson(content) {
+        /** @type {Metric[]} */
+        const out = [];
+        if (Array.isArray(content)) {
+            for (const item of content) {
+                if (item && typeof item.name === 'string' && typeof item.value === 'number') {
+                    out.push({ name: item.name, value: item.value, labels: item.labels || undefined });
+                }
+            }
+        } else if (content && typeof content === 'object') {
+            for (const [name, value] of Object.entries(content)) {
+                if (typeof value === 'number') out.push({ name, value });
+                else if (value && typeof value === 'object') {
+                    const val = Number(value.value);
+                    if (!Number.isNaN(val)) out.push({ name, value: val, labels: value.labels || undefined });
+                }
+            }
+        }
+        return out;
+    }
+
+    function aggregate(metrics) {
+        const sum = metrics.reduce((acc, m) => acc + (Number.isFinite(m.value) ? m.value : 0), 0);
+        return sum;
+    }
+
+    function formatNumber(n) {
+        if (!Number.isFinite(n)) return 'NaN';
+        if (Math.abs(n) >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+        if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+        if (Math.abs(n) >= 1e3) return (n / 1e3).toFixed(2) + 'K';
+        return String(Math.round(n * 100) / 100);
+    }
+
+    function renderTable() {
+        const filter = state.filterText.toLowerCase();
+        const rows = [];
+        for (const [name, metrics] of state.metricsByName.entries()) {
+            if (filter && !name.toLowerCase().includes(filter)) continue;
+            const agg = aggregate(metrics);
+            const details = metrics.map(m => {
+                const labelStr = m.labels ? '{' + Object.entries(m.labels).map(([k, v]) => `${k}="${v}"`).join(',') + '}' : '';
+                const src = m.source ? ` <span class="muted">@${m.source}</span>` : '';
+                return `<div class="mono">${labelStr} = <b>${formatNumber(m.value)}</b>${src}</div>`;
+            }).join('');
+            rows.push(`<tr><td class="mono">${name}</td><td><b>${formatNumber(agg)}</b></td><td>${details}</td></tr>`);
+        }
+        dom.tableBody.innerHTML = rows.join('');
+    }
+
+    function clearMetrics() {
+        state.metricsByName.clear();
+    }
+
+    function addMetricsToState(metrics, sourceLabel) {
+        for (const m of metrics) {
+            const arr = state.metricsByName.get(m.name) || [];
+            arr.push({ ...m, source: sourceLabel });
+            state.metricsByName.set(m.name, arr);
+        }
+    }
+
+    async function refreshOnce() {
+        if (state.sources.size === 0) {
+            setStatus('No sources. Add a URL or load a file.');
+            dom.tableBody.innerHTML = '';
+            return;
+        }
+        setStatus('Loading...');
+        clearMetrics();
+        const tasks = [];
+        for (const s of state.sources.values()) {
+            if (s.kind === 'url') {
+                tasks.push((async () => {
+                    try {
+                        const res = await fetchTextFromSource(s);
+                        if (res.type === 'json') {
+                            const parsed = parseJson(res.json);
+                            addMetricsToState(parsed, s.name);
+                        } else {
+                            const parsed = parsePrometheusText(res.text);
+                            addMetricsToState(parsed, s.name);
+                        }
+                    } catch (e) {
+                        console.error('Fetch failed for', s.name, e);
+                    }
+                })());
+            }
+        }
+        await Promise.all(tasks);
+        renderTable();
+        setStatus(`Updated ${new Date().toLocaleTimeString()} from ${state.sources.size} source(s)`);
+    }
+
+    function restartTimer() {
+        if (state.refreshTimer) window.clearInterval(state.refreshTimer);
+        if (!dom.autoRefresh.checked) return;
+        const sec = Math.max(2, Number(dom.refreshInterval.value) || 10);
+        state.refreshTimer = window.setInterval(refreshOnce, sec * 1000);
+    }
+
+    // Wire events
+    dom.addSourceBtn.addEventListener('click', () => {
+        const url = dom.urlInput.value.trim();
+        if (!url) return;
+        addSource('url', url);
+        dom.urlInput.value = '';
+        refreshOnce();
+    });
+    dom.urlInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') dom.addSourceBtn.click();
+    });
+    dom.fileInput.addEventListener('change', async (e) => {
+        const files = dom.fileInput.files;
+        if (!files || files.length === 0) return;
+        clearMetrics();
+        for (const file of files) {
+            const text = await file.text();
+            const isJson = file.name.toLowerCase().endsWith('.json');
+            let metrics;
+            if (isJson) {
+                try { metrics = parseJson(JSON.parse(text)); } catch { metrics = []; }
+            } else {
+                metrics = parsePrometheusText(text);
+            }
+            addMetricsToState(metrics, file.name);
+            addSource('file', file.name);
+        }
+        renderTable();
+        setStatus(`Loaded ${files.length} file(s)`);
+        dom.fileInput.value = '';
+    });
+    dom.refreshNowBtn.addEventListener('click', () => refreshOnce());
+    dom.refreshInterval.addEventListener('change', () => restartTimer());
+    dom.autoRefresh.addEventListener('change', () => restartTimer());
+    dom.filterInput.addEventListener('input', () => { state.filterText = dom.filterInput.value; renderTable(); });
+
+    document.getElementById('loadSampleTxt').addEventListener('click', async () => {
+        const url = 'metrics-sample.txt';
+        if (![...state.sources.values()].some(s => s.name === url)) addSource('url', url);
+        await refreshOnce();
+    });
+    document.getElementById('loadSampleJson').addEventListener('click', async () => {
+        const url = 'metrics-sample.json';
+        if (![...state.sources.values()].some(s => s.name === url)) addSource('url', url);
+        await refreshOnce();
+    });
+
+    // Initial
+    restartTimer();
+})();
+
+

--- a/docs/metrics-sample.json
+++ b/docs/metrics-sample.json
@@ -1,0 +1,7 @@
+[
+  { "name": "monad_workers", "value": 8 },
+  { "name": "monad_errors_total", "value": 5, "labels": { "type": "io" } },
+  { "name": "monad_cache_hits_total", "value": 1024 },
+  { "name": "monad_cache_misses_total", "value": 128 }
+]
+

--- a/docs/metrics-sample.txt
+++ b/docs/metrics-sample.txt
@@ -1,0 +1,17 @@
+# HELP monad_requests_total Total number of requests processed by Monad
+# TYPE monad_requests_total counter
+monad_requests_total{endpoint="/health",method="GET",status="200"} 128
+monad_requests_total{endpoint="/metrics",method="GET",status="200"} 64
+monad_requests_total{endpoint="/compute",method="POST",status="200"} 42
+monad_requests_total{endpoint="/compute",method="POST",status="500"} 3
+
+# HELP monad_compute_seconds Time spent computing
+# TYPE monad_compute_seconds gauge
+monad_compute_seconds{stage="prepare"} 0.123
+monad_compute_seconds{stage="execute"} 1.456
+monad_compute_seconds{stage="finalize"} 0.321
+
+# HELP monad_queue_size Size of internal job queue
+# TYPE monad_queue_size gauge
+monad_queue_size 7
+


### PR DESCRIPTION
## Summary\nAdd a lightweight static metrics dashboard under `docs/` to visualize Prometheus text or JSON metrics, plus sample data and README usage.\n\n## Changes\n- `docs/dashboard.html`\n- `docs/dashboard.js`\n- `docs/metrics-sample.txt`\n- `docs/metrics-sample.json`\n- `README.md`\n\n## Test Plan\n- Serve docs: `python3 -m http.server -d docs 8080`\n- Open `http://localhost:8080/dashboard.html`\n- Click "Load sample Prometheus" and "Load sample JSON"\n- Optionally add live endpoint (e.g., `http://localhost:9100/metrics`)\n\n## Risks/Impact\nDocs-only; no production code paths touched.